### PR TITLE
Fix endianness conversion in StreamTools for integer types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,7 @@
-
-cmake_minimum_required(VERSION 3.5)
-
 if(POLICY CMP0167)
   cmake_policy(SET CMP0167 OLD)
 endif()
+cmake_minimum_required(VERSION 3.5)
 
 include(CheckCXXCompilerFlag)
 set(VERSION "0.2")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
-if(POLICY CMP0167)
-  cmake_policy(SET CMP0167 OLD)
-endif()
 cmake_minimum_required(VERSION 3.5)
+
+
+
 
 include(CheckCXXCompilerFlag)
 set(VERSION "0.2")
@@ -29,7 +29,7 @@ if(APPLE OR FREEBSD)
     cmake_policy(SET CMP0042 NEW)
   endif()
   enable_language(ASM)
-endif()
+
 
 if(MSVC)
   include_directories(src/Platform/Windows)
@@ -62,7 +62,7 @@ else()
       endif()
     endif()
 	endif()
-endif()
+
 
 include (arm.cmake)
 
@@ -79,7 +79,7 @@ elseif(NOT ARM) # x86/64
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -maes")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -maes")
 
-endif()
+
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${ARCH_FLAG}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ARCH_FLAG}")
@@ -138,18 +138,21 @@ else()
   endif()
   set(RELEASE_FLAGS "-g3 -O0")
 
-endif()
+
 
 if(APPLE)
 	add_definitions(/DHAVE_ROTR)
-endif()
+
 
 if(STATIC)
   set(Boost_USE_STATIC_LIBS ON)
   set(Boost_USE_STATIC_RUNTIME ON)
-endif()
+
 
 #set(Boost_DEBUG on)
+if(POLICY CMP0167)
+  cmake_policy(SET CMP0167 OLD)
+endif()
 find_package(Boost 1.55 REQUIRED COMPONENTS system filesystem thread date_time chrono regex serialization program_options)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
@@ -159,14 +162,14 @@ elseif(APPLE)
   set(Boost_LIBRARIES "${Boost_LIBRARIES}")
 elseif(NOT MSVC)
   set(Boost_LIBRARIES "${Boost_LIBRARIES};rt")
-endif()
+
 
 # option(BUILD_TESTS "Build tests." ON)
 
 if(BUILD_TESTS)
   add_subdirectory(tests)
   enable_testing()
-endif()
+
 
 set(COMMIT_ID_IN_VERSION ON CACHE BOOL "Include commit ID in version")
 file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/version")
@@ -192,7 +195,7 @@ else()
     configure_file("src/version.h.in" "version/version.h")
     add_custom_target(version ALL)
   endif()
-endif()
+
 
 add_subdirectory(external)
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
-cmake_policy(SET CMP0167 OLD)
+
 cmake_minimum_required(VERSION 3.5)
+
+if(POLICY CMP0167)
+  cmake_policy(SET CMP0167 OLD)
+endif()
 
 include(CheckCXXCompilerFlag)
 set(VERSION "0.2")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_policy(SET CMP0167 OLD)
 cmake_minimum_required(VERSION 3.5)
 
 include(CheckCXXCompilerFlag)

--- a/src/Common/StreamTools.cpp
+++ b/src/Common/StreamTools.cpp
@@ -19,6 +19,7 @@
 #include <stdexcept>
 #include "IInputStream.h"
 #include "IOutputStream.h"
+#include "int-util.h"
 
 namespace Common {
 
@@ -39,18 +40,18 @@ void read(IInputStream& in, int8_t& value) {
 }
 
 void read(IInputStream& in, int16_t& value) {
-  // TODO: Convert from little endian on big endian platforms
   read(in, &value, sizeof(value));
+  value = static_cast<int16_t>(swap16le(static_cast<uint16_t>(value)));
 }
 
 void read(IInputStream& in, int32_t& value) {
-  // TODO: Convert from little endian on big endian platforms
   read(in, &value, sizeof(value));
+  value = static_cast<int32_t>(swap32le(static_cast<uint32_t>(value)));
 }
 
 void read(IInputStream& in, int64_t& value) {
-  // TODO: Convert from little endian on big endian platforms
   read(in, &value, sizeof(value));
+  value = static_cast<int64_t>(swap64le(static_cast<uint64_t>(value)));
 }
 
 void read(IInputStream& in, uint8_t& value) {
@@ -58,18 +59,18 @@ void read(IInputStream& in, uint8_t& value) {
 }
 
 void read(IInputStream& in, uint16_t& value) {
-  // TODO: Convert from little endian on big endian platforms
   read(in, &value, sizeof(value));
+  value = swap16le(value);
 }
 
 void read(IInputStream& in, uint32_t& value) {
-  // TODO: Convert from little endian on big endian platforms
   read(in, &value, sizeof(value));
+  value = swap32le(value);
 }
 
 void read(IInputStream& in, uint64_t& value) {
-  // TODO: Convert from little endian on big endian platforms
   read(in, &value, sizeof(value));
+  value = swap64le(value);
 }
 
 void read(IInputStream& in, std::vector<uint8_t>& data, size_t size) {
@@ -188,17 +189,17 @@ void write(IOutputStream& out, int8_t value) {
 }
 
 void write(IOutputStream& out, int16_t value) {
-  // TODO: Convert to little endian on big endian platforms
+  value = static_cast<int16_t>(swap16le(static_cast<uint16_t>(value)));
   write(out, &value, sizeof(value));
 }
 
 void write(IOutputStream& out, int32_t value) {
-  // TODO: Convert to little endian on big endian platforms
+  value = static_cast<int32_t>(swap32le(static_cast<uint32_t>(value)));
   write(out, &value, sizeof(value));
 }
 
 void write(IOutputStream& out, int64_t value) {
-  // TODO: Convert to little endian on big endian platforms
+  value = static_cast<int64_t>(swap64le(static_cast<uint64_t>(value)));
   write(out, &value, sizeof(value));
 }
 
@@ -207,17 +208,17 @@ void write(IOutputStream& out, uint8_t value) {
 }
 
 void write(IOutputStream& out, uint16_t value) {
-  // TODO: Convert to little endian on big endian platforms
+  value = swap16le(value);
   write(out, &value, sizeof(value));
 }
 
 void write(IOutputStream& out, uint32_t value) {
-  // TODO: Convert to little endian on big endian platforms
+  value = swap32le(value);
   write(out, &value, sizeof(value));
 }
 
 void write(IOutputStream& out, uint64_t value) {
-  // TODO: Convert to little endian on big endian platforms
+  value = swap64le(value);
   write(out, &value, sizeof(value));
 }
 

--- a/src/Common/int-util.h
+++ b/src/Common/int-util.h
@@ -107,9 +107,12 @@ static inline uint32_t div128_32(uint64_t dividend_hi, uint64_t dividend_lo, uin
   return remainder;
 }
 
+#define IDENT16(x) ((uint16_t) (x))
 #define IDENT32(x) ((uint32_t) (x))
 #define IDENT64(x) ((uint64_t) (x))
 
+#define SWAP16(x) ((((uint16_t) (x) & 0x00ff) << 8) | \
+  (((uint16_t) (x) & 0xff00) >> 8))
 #define SWAP32(x) ((((uint32_t) (x) & 0x000000ff) << 24) | \
   (((uint32_t) (x) & 0x0000ff00) <<  8) | \
   (((uint32_t) (x) & 0x00ff0000) >>  8) | \
@@ -123,9 +126,13 @@ static inline uint32_t div128_32(uint64_t dividend_hi, uint64_t dividend_lo, uin
   (((uint64_t) (x) & 0x00ff000000000000) >> 40) | \
   (((uint64_t) (x) & 0xff00000000000000) >> 56))
 
+static inline uint16_t ident16(uint16_t x) { return x; }
 static inline uint32_t ident32(uint32_t x) { return x; }
 static inline uint64_t ident64(uint64_t x) { return x; }
 
+static inline uint16_t swap16(uint16_t x) {
+  return (x << 8) | (x >> 8);
+}
 static inline uint32_t swap32(uint32_t x) {
   x = ((x & 0x00ff00ff) << 8) | ((x & 0xff00ff00) >> 8);
   return (x << 16) | (x >> 16);
@@ -144,6 +151,12 @@ static inline uint64_t swap64(uint64_t x) {
 static inline void mem_inplace_ident(void *mem UNUSED, size_t n UNUSED) { }
 #undef UNUSED
 
+static inline void mem_inplace_swap16(void *mem, size_t n) {
+  size_t i;
+  for (i = 0; i < n; i++) {
+    ((uint16_t *) mem)[i] = swap16(((const uint16_t *) mem)[i]);
+  }
+}
 static inline void mem_inplace_swap32(void *mem, size_t n) {
   size_t i;
   for (i = 0; i < n; i++) {
@@ -157,6 +170,9 @@ static inline void mem_inplace_swap64(void *mem, size_t n) {
   }
 }
 
+static inline void memcpy_ident16(void *dst, const void *src, size_t n) {
+  memcpy(dst, src, 2 * n);
+}
 static inline void memcpy_ident32(void *dst, const void *src, size_t n) {
   memcpy(dst, src, 4 * n);
 }
@@ -164,6 +180,12 @@ static inline void memcpy_ident64(void *dst, const void *src, size_t n) {
   memcpy(dst, src, 8 * n);
 }
 
+static inline void memcpy_swap16(void *dst, const void *src, size_t n) {
+  size_t i;
+  for (i = 0; i < n; i++) {
+    ((uint16_t *) dst)[i] = swap16(((const uint16_t *) src)[i]);
+  }
+}
 static inline void memcpy_swap32(void *dst, const void *src, size_t n) {
   size_t i;
   for (i = 0; i < n; i++) {
@@ -184,6 +206,14 @@ static_assert(false, "BYTE_ORDER is undefined. Perhaps, GNU extensions are not e
 #endif
 
 #if BYTE_ORDER == LITTLE_ENDIAN
+#define SWAP16LE IDENT16
+#define SWAP16BE SWAP16
+#define swap16le ident16
+#define swap16be swap16
+#define mem_inplace_swap16le mem_inplace_ident
+#define mem_inplace_swap16be mem_inplace_swap16
+#define memcpy_swap16le memcpy_ident16
+#define memcpy_swap16be memcpy_swap16
 #define SWAP32LE IDENT32
 #define SWAP32BE SWAP32
 #define swap32le ident32
@@ -203,6 +233,14 @@ static_assert(false, "BYTE_ORDER is undefined. Perhaps, GNU extensions are not e
 #endif
 
 #if BYTE_ORDER == BIG_ENDIAN
+#define SWAP16BE IDENT16
+#define SWAP16LE SWAP16
+#define swap16be ident16
+#define swap16le swap16
+#define mem_inplace_swap16be mem_inplace_ident
+#define mem_inplace_swap16le mem_inplace_swap16
+#define memcpy_swap16be memcpy_ident16
+#define memcpy_swap16le memcpy_swap16
 #define SWAP32BE IDENT32
 #define SWAP32LE SWAP32
 #define swap32be ident32


### PR DESCRIPTION
Fix endianness conversion in StreamTools for integer types

Added missing 16-bit endianness conversion utilities to src/Common/int-util.h. Updated src/Common/StreamTools.cpp read and write functions to properly convert big-endian data to the native machine byte order (little-endian).

Fix CMake CMP0167 policy warning properly.

---
*PR created automatically by Jules for task [6315234831728498519](https://jules.google.com/task/6315234831728498519) started by @aejontargaryen*