### PR TITLE
Fix v9 sync difficulty backwards compatibility

### DIFF
--- a/src/CryptoNoteCore/Currency.cpp
+++ b/src/CryptoNoteCore/Currency.cpp
@@ -1119,7 +1119,7 @@ double Currency::getBurnPercentage() const {
 	   		   uint64_t difficulty_plate = isTestnet() ? 10000 : 100000;
 
 
-			   assert(timestamps.size() == cumulativeDifficulties.size() && timestamps.size() <= static_cast<uint64_t>(N + 1));
+			   assert(timestamps.size() == cumulativeDifficulties.size());
 
 			   // If it's a new coin, do startup code. Do not remove in case other coins copy your code.
 			   // uint64_t difficulty_guess = 10000;

--- a/src/CryptoNoteCore/Currency.h
+++ b/src/CryptoNoteCore/Currency.h
@@ -177,11 +177,6 @@ public:
         // v10+: LWMA-1 with N=39. Provide N+1=40 timestamps.
         return 40;
       }
-      else if (blockMajorVersion >= BLOCK_MAJOR_VERSION_7)
-      {
-        // v7-v9: single-window LWMA, DIFFICULTY_WINDOW_V4=45 is correct here
-        return difficultyBlocksCount4() + 1;
-      }
       else if (blockMajorVersion >= BLOCK_MAJOR_VERSION_3)
       {
         return difficultyBlocksCount3() + 1;


### PR DESCRIPTION
The v1.10.00 daemon was failing to sync with the older v1.9.3 network because v1.9.3 had a bug where the `difficultyBlocksCountByBlockVersion` returned 61 blocks for v7-v9 instead of 46 blocks. The `nextDifficultyV5` function expects N=45, leading to a 15-block lag when evaluating timestamps on the live network. This patch removes the explicit check that "fixed" this bug in v1.10.00 to preserve backwards compatibility during syncing, while removing the strict assert constraint that could cause a crash. The fix ensures that v9 block hashes validate correctly and the node can sync up to v10.

---
*PR created automatically by Jules for task [17649541517822885316](https://jules.google.com/task/17649541517822885316) started by @aejontargaryen*