### PR TITLE
fix(build): use ARM hardware AES on Apple Silicon instead of software fallback

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -169,11 +169,17 @@ add_dependencies(CryptoNoteCore version)
 # Always try to enable AES-NI for GCC/Clang on non-Android x86_64 systems
 if (CMAKE_C_COMPILER_ID MATCHES "GNU|Clang" AND NOT ANDROID)
     if (CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND (CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64" OR CMAKE_OSX_ARCHITECTURES STREQUAL "arm64"))
-        # Apple Silicon: skip AES/SSE flags, use software AES
+        # Apple Silicon: enable ARM crypto extensions for hardware AES.
+        # Apple M-series CPUs have ARMv8 crypto extensions (AES, PMULL, SHA1, SHA2).
+        # We MUST use hardware AES on ARM64, not the NO_AES software fallback —
+        # the portable software path in slow-hash.c produces CryptoNight hashes
+        # that diverge from the x86_64/ARM hardware paths used by network miners,
+        # causing "too weak proof of work" rejections when syncing the mainnet chain.
         # FORCE_USE_HEAP: allocate cn_slow_hash scratchpad on heap instead of stack
-        # to avoid stack overflow (2MB buffer vs 512KB default thread stack size)
-        target_compile_definitions(Crypto PRIVATE NO_AES FORCE_USE_HEAP)
-        message(STATUS "Apple Silicon detected, using software AES with heap allocation for Crypto library")
+        # to avoid stack overflow (2MB buffer vs 512KB default thread stack size).
+        target_compile_options(Crypto PRIVATE -march=armv8-a+crypto)
+        target_compile_definitions(Crypto PRIVATE FORCE_USE_HEAP)
+        message(STATUS "Apple Silicon detected, using ARM hardware AES (armv8-a+crypto) with heap allocation for Crypto library")
     else()
         # Enable AES-NI and SSE instructions for cryptographic operations
         target_compile_options(Crypto PRIVATE -maes -msse2 -msse4.1 -msse4.2)


### PR DESCRIPTION
## Summary

Fixes the **"too weak proof of work"** sync failure on Apple Silicon Macs running the hearth branch (and the v1.10.00 release) against the v1.9.3 mainnet chain.

## Root Cause

`src/CMakeLists.txt` defines `NO_AES` on Apple Silicon, which forces `slow-hash.c` onto the *"Portable implementation as a fallback"* path (starting at line 1397). That portable software-AES path produces CryptoNight hashes that **do not match** the hashes produced by:

- The x86_64 hardware AES-NI path (used by the vast majority of network miners)
- The ARM hardware AES path (used by `__aarch64__` + `__ARM_FEATURE_CRYPTO`)

Because the computed PoW hashes diverge from what miners actually produced, every V9 block fails `check_hash()` during mainnet sync with `too weak proof of work`.

## Why v1.9.3 Works and Hearth Doesn't

v1.9.3's `CMakeLists.txt` has **no** Apple Silicon special case — the default compiler defines `__aarch64__` and `__ARM_FEATURE_CRYPTO` on Apple Silicon, so `slow-hash.c` naturally picks the ARM hardware AES path (lines 836–1395). That path produces hashes identical to x86_64 AES-NI.

The hearth branch added an explicit Apple Silicon block that *disables* AES (`NO_AES`) — likely an attempt to dodge a build/runtime issue — but the cure is worse than the disease: software AES produces wrong hashes for network sync.

## Fix

Drop `NO_AES`. Add `-march=armv8-a+crypto` so the compiler unambiguously enables the ARM crypto extensions and defines `__ARM_FEATURE_CRYPTO`. Keep `FORCE_USE_HEAP` — the 2MB CryptoNight scratchpad still won't fit the default thread stack.

```diff
-        # Apple Silicon: skip AES/SSE flags, use software AES
-        target_compile_definitions(Crypto PRIVATE NO_AES FORCE_USE_HEAP)
+        # Apple Silicon: enable ARM crypto extensions for hardware AES.
+        target_compile_options(Crypto PRIVATE -march=armv8-a+crypto)
+        target_compile_definitions(Crypto PRIVATE FORCE_USE_HEAP)
```

## Test plan

- [ ] Rebuild from clean on Apple Silicon (M1/M2/M3): `rm -rf build && cmake -B build && cmake --build build`
- [ ] Verify CMake output: `Apple Silicon detected, using ARM hardware AES (armv8-a+crypto) with heap allocation for Crypto library`
- [ ] Start fresh daemon on Apple Silicon Mac and sync from genesis against the v1.9.3 mainnet — confirm it passes block 988,002 (first post-checkpoint block) and beyond without `too weak proof of work` errors
- [ ] Confirm Intel Mac / Linux x86_64 builds are unaffected (same AES-NI path as before)
- [ ] Confirm Linux ARM64 (Raspberry Pi etc.) builds are unaffected — they fall through to the else branch and weren't using the Apple Silicon path anyway

## Related

This is the root cause behind the symptom investigated in the existing fix attempts on `origin/fix-v9-block-hashing-blob-*` and `origin/jules-fix-difficulty-v5-*` — neither of those branches were the actual culprit; they were chasing differences in difficulty/serialization code that turned out to be functionally identical to v1.9.3. The real divergence was in the CryptoNight implementation selected at build time on Apple Silicon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)