### PR TITLE
fix(consensus): hash v9+ blocks over block-header blob, not parent-block blob

### DIFF
--- a/src/CryptoNoteCore/CryptoNoteFormatUtils.cpp
+++ b/src/CryptoNoteCore/CryptoNoteFormatUtils.cpp
@@ -565,6 +565,16 @@ bool get_block_longhash(cn_context &context, const Block& b, Hash& res) {
     if (!get_block_hashing_blob(b, bd)) {
       return false;
     }
+  } else if (b.majorVersion >= BLOCK_MAJOR_VERSION_9) {
+    // v9+ blocks are PoW-hashed over get_block_hashing_blob (block header + tree
+    // root + tx count) rather than get_parent_block_hashing_blob. The parent-
+    // block serializer prepends parentBlock.{major,minor}Version/timestamp/
+    // prevId/nonce/merkleRoot, which yields the wrong byte prefix for v9 blocks
+    // and causes "too weak proof of work" rejections when syncing mainnet
+    // (network miners hash the block-header blob, not the parent blob).
+    if (!get_block_hashing_blob(b, bd)) {
+      return false;
+    }
   } else if (b.majorVersion >= BLOCK_MAJOR_VERSION_2) {
     if (!get_parent_block_hashing_blob(b, bd)) {
       return false;


### PR DESCRIPTION
## Summary

Fixes the **\"too weak proof of work\"** sync failure on the hearth branch (and the v1.10.00 release) when validating v9 mainnet blocks against the live v1.9.3 chain.

## Root cause

`get_block_longhash()` in `src/CryptoNoteCore/CryptoNoteFormatUtils.cpp` routes all blocks with `majorVersion >= BLOCK_MAJOR_VERSION_2` through `get_parent_block_hashing_blob()`. That serializer prepends the embedded parent block:

```
parentBlock.majorVersion / minorVersion / timestamp / prevId / nonce / merkleRoot / txNum
```

Network miners on the v1.9.3 chain produce v9 PoW over `get_block_hashing_blob()` instead:

```
block.majorVersion / minorVersion / prevId  +  treeRootHash  +  txCount
```

The two blobs start with different bytes and have different layouts, so feeding the parent-block blob into `cn_slow_hash()` yields a PoW hash that doesn't match what miners produced. Symptom: the daemon computes a constant, byte-identical \"random-looking\" hash (e.g. `11a8d02b5f761c2a...`) that's way too high to satisfy the difficulty target, and rejects every v9 block past its checkpoint zone.

## Why the AES fix in #53 didn't resolve it

The Apple Silicon `NO_AES` fallback was a real footgun, but the cn_slow_hash result observed on Mac was byte-identical before and after #53 — meaning either the user wasn't on Apple Silicon, or the hardware-AES path was already getting selected. Either way, the input bytes fed into cn_slow_hash were the problem, not the AES implementation.

## Fix

Add a v9+ branch above the existing v2+ branch so v9 and v10 blocks use `get_block_hashing_blob()`. v2-v8 keep the parent-block blob (unchanged).

```diff
   } else if (b.majorVersion == BLOCK_MAJOR_VERSION_1) {
     if (!get_block_hashing_blob(b, bd)) { return false; }
+  } else if (b.majorVersion >= BLOCK_MAJOR_VERSION_9) {
+    if (!get_block_hashing_blob(b, bd)) { return false; }
   } else if (b.majorVersion >= BLOCK_MAJOR_VERSION_2) {
     if (!get_parent_block_hashing_blob(b, bd)) { return false; }
   }
```

Cherry-picked from commit `25d8750c0d4` on the stranded `fix-v9-block-hashing-blob-9959788317054158190` branch, with a clearer explanatory comment.

## Test plan

- [ ] Build clean: \`rm -rf build && cmake -B build && cmake --build build\`
- [ ] Start daemon and sync from genesis against the v1.9.3 mainnet — confirm it passes the first non-checkpointed v9 block (around 988,002 on hearth's checkpoint set) and continues without \"too weak proof of work\" errors
- [ ] Confirm v1-v8 historical blocks still validate (these still go through `get_parent_block_hashing_blob`)
- [ ] Spot-check that the failing block reported by users (e.g. `fcdbfdaa...` around height 1,000,001) now passes PoW with the same expected difficulty

## Related

- #53 (Apple Silicon AES fix) — necessary cleanup but not the actual root cause of this specific symptom
- Stranded fix branches that identified pieces of this: `origin/fix-v9-block-hashing-blob-*`, `origin/jules-fix-difficulty-v5-*`