### PR TITLE
Revert v9 block-header-blob hashing fix (#54)

### DIFF
--- a/src/CryptoNoteCore/CryptoNoteFormatUtils.cpp
+++ b/src/CryptoNoteCore/CryptoNoteFormatUtils.cpp
@@ -565,16 +565,6 @@ bool get_block_longhash(cn_context &context, const Block& b, Hash& res) {
     if (!get_block_hashing_blob(b, bd)) {
       return false;
     }
-  } else if (b.majorVersion >= BLOCK_MAJOR_VERSION_9) {
-    // v9+ blocks are PoW-hashed over get_block_hashing_blob (block header + tree
-    // root + tx count) rather than get_parent_block_hashing_blob. The parent-
-    // block serializer prepends parentBlock.{major,minor}Version/timestamp/
-    // prevId/nonce/merkleRoot, which yields the wrong byte prefix for v9 blocks
-    // and causes "too weak proof of work" rejections when syncing mainnet
-    // (network miners hash the block-header blob, not the parent blob).
-    if (!get_block_hashing_blob(b, bd)) {
-      return false;
-    }
   } else if (b.majorVersion >= BLOCK_MAJOR_VERSION_2) {
     if (!get_parent_block_hashing_blob(b, bd)) {
       return false;


### PR DESCRIPTION
Reverts #54.

## Why

PR #54 was a wrong root-cause guess. Field testing on Apple M1 with the AES fix from #53 applied and a clean rebuild produced yet another wrong hash:

| Blob format | AES path | Computed hash for block 1,000,001 |
|-------------|----------|------------------------------------|
| parent_block | software (pre #53) | \`11a8d02b5f761c2a...757eff\` ❌ |
| block_header | software (pre #53) | \`c45ff3d8e536961d...4f7de76\` ❌ |
| block_header | **hardware** (post #53) | \`eded3840999f9a17...62dba144d\` ❌ |

Explorer confirms block 1,000,001's actual difficulty is **31,300,056** — exactly what our daemon computes — so the difficulty algorithm is correct. The problem is purely the PoW hash, and three blob/AES combinations have failed.

The one combination not tried: **parent_block_blob + hardware AES**, which is what v1.9.3 source compiles to on AES-NI capable hosts and what network miners produce. Reverting #54 restores the v1.9.3-source hashing path; combined with #53, the daemon should now match the network.

## After merge

1. \`git pull\`
2. \`rm -rf build && cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j\$(sysctl -n hw.ncpu)\`
3. Confirm CMake output includes \`Apple Silicon detected, using ARM hardware AES (armv8-a+crypto)\`
4. Run \`build/release/src/fuegod\` — should advance past 1,000,001

## If this still fails

Then the issue is genuinely in cn_slow_hash on M1 vs x86 (or in deserialization producing a different in-memory Block than what the network produced). At that point the next step is diagnostic logging — print the input blob bytes for the failing block on M1 and compare with what a Linux x86 v1.9.3 daemon produces for the same block.