### PR TITLE
Fix Windows CI runner image and OpenSSL installation

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   build-windows:
     name: Windows
-    runs-on: windows-2025
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
         with:
@@ -22,9 +22,6 @@ jobs:
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.1
-
-      - name: Install OpenSSL
-        run: choco install openssl -y
 
       - name: Install Boost 1.85
         shell: pwsh
@@ -39,8 +36,7 @@ jobs:
         shell: pwsh
         run: |
           cmake -S "${{ github.workspace }}" -B "${{ github.workspace }}/build" -G "Visual Studio 17 2022" -A x64 `
-            -DBOOST_ROOT="C:\boost" `
-            -DOPENSSL_ROOT_DIR="C:/Program Files/OpenSSL-Win64"
+            -DBOOST_ROOT="C:\boost"
           cmake --build "${{ github.workspace }}/build" --config Release -j 4
 
   build-ubuntu24:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-windows:
     name: Windows
-    runs-on: windows-2025
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
         with:
@@ -16,12 +16,6 @@ jobs:
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1
-
-      - name: Install OpenSSL
-        shell: pwsh
-        run: |
-          choco install openssl -y
-          echo "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL-Win64" >> $env:GITHUB_ENV
 
       - name: Install Boost 1.85
         shell: pwsh
@@ -42,8 +36,7 @@ jobs:
 
           cmake -S "${{ github.workspace }}" -B "${{ github.workspace }}/build" `
             -G "Visual Studio 17 2022" -A x64 `
-            -DBOOST_ROOT="C:\boost" `
-            -DOPENSSL_ROOT_DIR="$env:OPENSSL_ROOT_DIR"
+            -DBOOST_ROOT="C:\boost"
           cmake --build "${{ github.workspace }}/build" --config Release -j $env:NUMBER_OF_PROCESSORS
 
           cd "${{ github.workspace }}/build/src/Release"


### PR DESCRIPTION
Update the runner version from `windows-2025` to `windows-2022` and omit explicit OpenSSL resolution path to fix breaking workflows on Windows.
