### PR TITLE
Update README.md -- Linux(Ubuntu/Debian) Build Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,15 +66,17 @@ _____________________________
 #### 1. Install Dependencies
 
 ```bash
-sudo apt-get install build-essential git cmake libboost-all-dev libjsoncpp-dev libssl-dev
+sudo apt install build-essential git cmake libboost-all-dev libjsoncpp-dev libssl-dev
 ```
 
 #### 2. Clone and Build
 
 ```bash
-git clone https://github.com/usexfg/fuego
-cd fuego
-make
+git clone --recursive https://github.com/usexfg/fuego-suite
+cd fuego-suite && git submodule init && git submodule update
+mkdir build && cd build
+cmake ..
+make -j$(nproc)
 ```
 
 Binaries will be in `build/release/src/`. The Go TUI builds automatically if Go 1.24+ is installed.


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Refresh Linux (Ubuntu/Debian) build instructions in README
<code>📝 Documentation</code> <code>🕐 Less than 5 minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Update Ubuntu/Debian dependency install command to use <b><i>apt</i></b>.
• Switch clone instructions to the new <b><i>fuego-suite</i></b> repo with submodules.
• Document an out-of-tree CMake build and parallel <b><i>make</i></b> invocation.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
A["Install deps (apt)"] --> B["Clone repo (--recursive)"] --> C["Init/update submodules"] --> D["Create build dir"] --> E["Configure (cmake ..)"] --> F["Build (make -j)"] --> G["Artifacts in build output"]
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Rely on `git clone --recursive` (drop explicit submodule commands)</b></summary>

- ➕ Shorter, less redundant instructions (recursive clone already initializes/updates submodules).
- ➕ Reduces the chance of users running submodule commands in the wrong directory.
- ➖ If users download a ZIP/tarball or clone without `--recursive`, they still need a submodule update step (would need an explicit fallback note).

</details>

<details>
<summary><b>2. Document a single recommended path + a fallback path</b></summary>

- ➕ Keeps primary instructions minimal while still helping users who forgot `--recursive`.
- ➕ Makes troubleshooting clearer when submodules are missing.
- ➖ Slightly longer README section.

</details>

**Recommendation:** Keep the new CMake out-of-tree build steps as written, but consider removing `git submodule init &amp;&amp; git submodule update` from the primary path when using `--recursive`, or explicitly label it as a fallback for non-recursive clones. This avoids redundant commands and reduces user confusion.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Documentation</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>README.md</strong> <code>Update Ubuntu/Debian build steps for fuego-suite + CMake build</code> <code>+6/-4</code></summary>

<br/>

>Update Ubuntu/Debian build steps for fuego-suite + CMake build
>
><pre>
>• Replaces &#x27;apt-get&#x27; with &#x27;apt&#x27; for dependency installation. Updates clone/build instructions to use the &#x27;fuego-suite&#x27; repository with submodules and documents an out-of-tree CMake build with parallel compilation.
></pre>
>
><a href='https://github.com/usexfg/fuego-suite/pull/58/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5'>README.md</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>