### PR TITLE
⚡ Bolt: Remove unused O(N) lookup in WalletLegacy balance calculation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+## 2024-07-29 - O(N) Array Allocation Removal in WalletLegacy
+
+**Learning:** `std::accumulate` and lambdas can create significant overhead if they capture expensive copies of unused variables. In `WalletLegacy::calculateDepositsAmount` and `calculateInvestmentsAmount`, the lambda was passing the large `heights` vector by copy, even though it was completely unused inside the lambda. The `heights` vector was being explicitly built by querying transaction history over N transfers before passing it into this function, only for the lambda to throw it away.
+
+**Action:** Look out for complex data transformations (like fetching block heights for a list of transactions) that exist *purely* to satisfy a function signature, but are never consumed by the business logic inside the function. Dead code elimination isn't just about deleting single lines; it's about removing the expensive prep work too.

--- a/src/WalletLegacy/WalletLegacy.cpp
+++ b/src/WalletLegacy/WalletLegacy.cpp
@@ -111,9 +111,8 @@ private:
   std::future<std::error_code> future;
 };
 
-uint64_t calculateDepositsAmount(const std::vector<CryptoNote::TransactionOutputInformation>& transfers, const CryptoNote::Currency& currency, const std::vector<uint32_t> heights) {
-	int index = 0;
-  return std::accumulate(transfers.begin(), transfers.end(), static_cast<uint64_t>(0), [&currency, &index, heights] (uint64_t sum, const CryptoNote::TransactionOutputInformation& deposit) {
+uint64_t calculateDepositsAmount(const std::vector<CryptoNote::TransactionOutputInformation>& transfers) {
+  return std::accumulate(transfers.begin(), transfers.end(), static_cast<uint64_t>(0), [] (uint64_t sum, const CryptoNote::TransactionOutputInformation& deposit) {
     if (deposit.term % 64800 != 0)
     {
       return sum + deposit.amount;
@@ -122,13 +121,11 @@ uint64_t calculateDepositsAmount(const std::vector<CryptoNote::TransactionOutput
     {
       return sum;
     }
-
   });
 }
 
-uint64_t calculateInvestmentsAmount(const std::vector<CryptoNote::TransactionOutputInformation>& transfers, const CryptoNote::Currency& currency, const std::vector<uint32_t> heights) {
-	int index = 0;
-  return std::accumulate(transfers.begin(), transfers.end(), static_cast<uint64_t>(0), [&currency, &index, heights] (uint64_t sum, const CryptoNote::TransactionOutputInformation& deposit) {
+uint64_t calculateInvestmentsAmount(const std::vector<CryptoNote::TransactionOutputInformation>& transfers) {
+  return std::accumulate(transfers.begin(), transfers.end(), static_cast<uint64_t>(0), [] (uint64_t sum, const CryptoNote::TransactionOutputInformation& deposit) {
     if (deposit.term % 64800 == 0)
     {
       return sum + deposit.amount;
@@ -137,7 +134,6 @@ uint64_t calculateInvestmentsAmount(const std::vector<CryptoNote::TransactionOut
     {
       return sum;
     }
-
   });
 }
 
@@ -1613,28 +1609,15 @@ std::vector<TransactionId> WalletLegacy::deleteOutdatedUnconfirmedTransactions()
 uint64_t WalletLegacy::calculateActualDepositBalance() {
   std::vector<TransactionOutputInformation> transfers;
   m_transferDetails->getOutputs(transfers, ITransfersContainer::IncludeTypeDeposit | ITransfersContainer::IncludeStateUnlocked);
-  std::vector<uint32_t> heights = getTransactionHeights(transfers);
-  return calculateDepositsAmount(transfers, m_currency, heights) - m_transactionsCache.countUnconfirmedSpentDepositsTotalAmount();
+  return calculateDepositsAmount(transfers) - m_transactionsCache.countUnconfirmedSpentDepositsTotalAmount();
 }
 
 uint64_t WalletLegacy::calculateActualInvestmentBalance() {
   std::vector<TransactionOutputInformation> transfers;
   m_transferDetails->getOutputs(transfers, ITransfersContainer::IncludeTypeDeposit | ITransfersContainer::IncludeStateUnlocked);
-  std::vector<uint32_t> heights = getTransactionHeights(transfers);
-  return calculateInvestmentsAmount(transfers, m_currency, heights);
+  return calculateInvestmentsAmount(transfers);
 }
 
-std::vector<uint32_t> WalletLegacy::getTransactionHeights(const std::vector<TransactionOutputInformation> transfers){
-  std::vector<uint32_t> heights;
-  for (auto transfer : transfers){
-	  Crypto::Hash hash = transfer.transactionHash;
-	  TransactionInformation info;
-	  bool ok = m_transferDetails->getTransactionInformation(hash, info, NULL, NULL);
-	  assert(ok);
-	  heights.push_back(info.blockHeight);
-  }
-  return heights;
-}
 
 
 uint64_t WalletLegacy::calculatePendingDepositBalance() {
@@ -1642,8 +1625,7 @@ uint64_t WalletLegacy::calculatePendingDepositBalance() {
   m_transferDetails->getOutputs(transfers, ITransfersContainer::IncludeTypeDeposit
                                 | ITransfersContainer::IncludeStateLocked
                                 | ITransfersContainer::IncludeStateSoftLocked);
-  std::vector<uint32_t> heights = getTransactionHeights(transfers);
-  return calculateDepositsAmount(transfers, m_currency, heights);
+  return calculateDepositsAmount(transfers);
 }
 
 uint64_t WalletLegacy::calculatePendingInvestmentBalance() {
@@ -1651,8 +1633,7 @@ uint64_t WalletLegacy::calculatePendingInvestmentBalance() {
   m_transferDetails->getOutputs(transfers, ITransfersContainer::IncludeTypeDeposit
                                 | ITransfersContainer::IncludeStateLocked
                                 | ITransfersContainer::IncludeStateSoftLocked);
-  std::vector<uint32_t> heights = getTransactionHeights(transfers);
-  return calculateInvestmentsAmount(transfers, m_currency, heights);
+  return calculateInvestmentsAmount(transfers);
 }
 
 uint64_t WalletLegacy::calculateActualHeatBalance() {

--- a/src/WalletLegacy/WalletLegacy.h
+++ b/src/WalletLegacy/WalletLegacy.h
@@ -180,8 +180,6 @@ public:
 
   std::vector<TransactionId> deleteOutdatedUnconfirmedTransactions();
 
-  std::vector<uint32_t> getTransactionHeights(std::vector<TransactionOutputInformation> transfers);
-
   // Burn transaction management
   // Deprecated BPDF/STARK methods removed (C3/C8 security fixes)
 


### PR DESCRIPTION
💡 What:
Removed the `getTransactionHeights` function and removed the `heights` vector parameter from `calculateDepositsAmount` and `calculateInvestmentsAmount`.

🎯 Why:
Before this change, the `heights` array was computed by performing a database lookup on every single transaction in a vector of transfers just to satisfy the function signatures of `calculateDepositsAmount` and `calculateInvestmentsAmount`. However, those functions never actually used the `heights` parameter (it was captured by the `std::accumulate` lambdas but ignored). 

📊 Impact:
- Removes O(N) database reads per balance calculation call.
- Removes deep copies of large arrays.
- Less allocation pressure.
- Reduces memory usage and CPU cycles, measurably speeding up wallet processing time, especially for wallets with large transaction histories.

🔬 Measurement:
Run the wallet core tests or check execution times for `calculateActualDepositBalance`, `calculateActualInvestmentBalance`, `calculatePendingDepositBalance`, and `calculatePendingInvestmentBalance`.

---
*PR created automatically by Jules for task [4923161963715314445](https://jules.google.com/task/4923161963715314445) started by @aejontargaryen*